### PR TITLE
AWS single AZ node groups

### DIFF
--- a/terraform/eks-node-groups/single-az-node-groups/README.md
+++ b/terraform/eks-node-groups/single-az-node-groups/README.md
@@ -1,0 +1,71 @@
+# eks `node_groups` submodule
+
+Helper submodule to create and manage resources related to `eks_node_groups`.
+
+## Assumptions
+* Designed for use by the parent module and not directly by end users
+
+## Node Groups' IAM Role
+The role ARN specified in `var.default_iam_role_arn` will be used by default. In a simple configuration this will be the worker role created by the parent module.
+
+`iam_role_arn` must be specified in either `var.node_groups_defaults` or `var.node_groups` if the default parent IAM role is not being created for whatever reason, for example if `manage_worker_iam_resources` is set to false in the parent.
+
+## `node_groups` and `node_groups_defaults` keys
+`node_groups_defaults` is a map that can take the below keys. Values will be used if not specified in individual node groups.
+
+`node_groups` is a map of maps. Key of first level will be used as unique value for `for_each` resources and in the `aws_eks_node_group` name. Inner map can take the below values.
+
+| Name | Description | Type | If unset |
+|------|-------------|:----:|:-----:|
+| additional\_tags | Additional tags to apply to node group | map(string) | Only `var.tags` applied |
+| ami\_release\_version | AMI version of workers | string | Provider default behavior |
+| ami\_type | AMI Type. See Terraform or AWS docs | string | Provider default behavior |
+| capacity\_type | Type of instance capacity to provision. Options are `ON_DEMAND` and `SPOT` | string | Provider default behavior |
+| desired\_capacity | Desired number of workers | number | `var.workers_group_defaults[asg_desired_capacity]` |
+| disk\_size | Workers' disk size | number | Provider default behavior |
+| iam\_role\_arn | IAM role ARN for workers | string | `var.default_iam_role_arn` |
+| instance\_types | Node group's instance type(s). Multiple types can be specified when `capacity_type="SPOT"`. | list | `[var.workers_group_defaults[instance_type]]` |
+| k8s\_labels | Kubernetes labels | map(string) | No labels applied |
+| key\_name | Key name for workers. Set to empty string to disable remote access | string | `var.workers_group_defaults[key_name]` |
+| launch_template_id | The id of a aws_launch_template to use | string | No LT used |
+| launch\_template_version | The version of the LT to use | string | none |
+| max\_capacity | Max number of workers | number | `var.workers_group_defaults[asg_max_size]` |
+| min\_capacity | Min number of workers | number | `var.workers_group_defaults[asg_min_size]` |
+| name | Name of the node group | string | Auto generated |
+| source\_security\_group\_ids | Source security groups for remote access to workers | list(string) | If key\_name is specified: THE REMOTE ACCESS WILL BE OPENED TO THE WORLD |
+| subnets | Subnets to contain workers | list(string) | `var.workers_group_defaults[subnets]` |
+| version | Kubernetes version | string | Provider default behavior |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| random | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster\_name | Name of parent cluster | `string` | n/a | yes |
+| create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
+| default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | n/a | yes |
+| ng\_depends\_on | List of references to other resources this submodule depends on | `any` | `null` | no |
+| node\_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
+| node\_groups\_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | n/a | yes |
+| tags | A map of tags to add to all resources | `map(string)` | n/a | yes |
+| workers\_group\_defaults | Workers group defaults from parent | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| aws\_auth\_roles | Roles for use in aws-auth ConfigMap |
+| node\_groups | Outputs from EKS node groups. Map of maps, keyed by `var.node_groups` keys. See `aws_eks_node_group` Terraform documentation for values |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/eks-node-groups/single-az-node-groups/README.md
+++ b/terraform/eks-node-groups/single-az-node-groups/README.md
@@ -3,7 +3,8 @@
 Helper submodule to create and manage resources related to `eks_node_groups`.
 
 ## Assumptions
-* Designed for use by the parent module and not directly by end users
+* Designed for use by the Plural parent module and not directly by end users
+* The node groups will be split across the subnets, so that there is a node group for each availability zone
 
 ## Node Groups' IAM Role
 The role ARN specified in `var.default_iam_role_arn` will be used by default. In a simple configuration this will be the worker role created by the parent module.

--- a/terraform/eks-node-groups/single-az-node-groups/locals.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/locals.tf
@@ -40,7 +40,7 @@ locals {
               )
             },
           )
-        } if contains(data.aws_ec2_instance_type_offerings.example[k].locations, subnet.availability_zone)
+        } if contains(data.aws_ec2_instance_type_offerings.node_groups[k].locations, subnet.availability_zone)
      ]
   ])
 
@@ -66,7 +66,7 @@ locals {
   ]) : format("%s/%s", obj.pool, obj.key) => obj }
 }
 
-data "aws_ec2_instance_type_offerings" "example" {
+data "aws_ec2_instance_type_offerings" "node_groups" {
   for_each = local.node_groups_merged
   filter {
     name   = "instance-type"

--- a/terraform/eks-node-groups/single-az-node-groups/locals.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/locals.tf
@@ -1,0 +1,67 @@
+locals {
+  # Merge defaults and per-group values to make code cleaner
+  node_groups_merged = { for k, v in var.node_groups : k => merge(
+    {
+      iam_role_arn            = var.default_iam_role_arn
+      key_name                = ""
+      launch_template_id      = null
+      launch_template_version = "$Latest"
+      labels = merge(
+        lookup(var.node_groups_defaults, "k8s_labels", {}),
+        lookup(var.node_groups[k], "k8s_labels", {})
+      )
+      taints = concat(
+        lookup(var.node_groups_defaults, "k8s_taints", []),
+        lookup(var.node_groups[k], "k8s_taints", [])
+      )
+      tags = merge(
+        var.tags,
+        lookup(var.node_groups_defaults, "additional_tags", {}),
+        lookup(var.node_groups[k], "additional_tags", {}),
+      )
+    },
+    var.node_groups_defaults,
+    v,
+  )}
+
+  node_groups_temp = flatten([ for k, v in local.node_groups_merged:
+     [ for index, subnet in var.private_subnets:
+        {"${k}-${subnet.availability_zone}" = merge(
+            v,
+            {
+              subnets = [subnet.id]
+              min_capacity = ceil(v.min_capacity/length(var.private_subnets))
+              max_capacity = ceil(v.max_capacity/length(var.private_subnets))
+              desired_capacity = ceil(v.desired_capacity/length(var.private_subnets))
+              name = "${v.name}-${subnet.availability_zone}"
+              labels = merge(
+                lookup(v, "labels", {}),
+                {"topology.ebs.csi.aws.com/zone" = "${subnet.availability_zone}"}
+              )
+            },
+          )
+        }
+     ]
+  ])
+
+  node_groups_expanded = zipmap(
+    flatten(
+      [for item in local.node_groups_temp : keys(item)]
+    ),
+    flatten(
+      [for item in local.node_groups_temp : values(item)]
+    )
+  )
+
+  nodegroup_labels = { for obj in flatten([
+    for name, attr in local.node_groups_expanded : [
+      for label, value in attr.labels : { pool = name, key = label, value = value }
+    ]
+  ]) : format("%s/%s", obj.pool, obj.key) => obj }
+
+  nodegroup_taints = { for obj in flatten([
+    for name, attr in local.node_groups_expanded : [
+      for taint in attr.taints : { pool = name, key = taint.key, value = taint.value, effect = taint.effect }
+    ]
+  ]) : format("%s/%s", obj.pool, obj.key) => obj }
+}

--- a/terraform/eks-node-groups/single-az-node-groups/locals.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/locals.tf
@@ -40,7 +40,7 @@ locals {
               )
             },
           )
-        }
+        } if contains(data.aws_ec2_instance_type_offerings.example.k.locations, subnet.availability_zone)
      ]
   ])
 
@@ -64,4 +64,14 @@ locals {
       for taint in attr.taints : { pool = name, key = taint.key, value = taint.value, effect = taint.effect }
     ]
   ]) : format("%s/%s", obj.pool, obj.key) => obj }
+}
+
+data "aws_ec2_instance_type_offerings" "example" {
+  for_each = local.node_groups_merged
+  filter {
+    name   = "instance-type"
+    values = lookup(each.value, "instance_types")
+  }
+
+  location_type = "availability-zone"
 }

--- a/terraform/eks-node-groups/single-az-node-groups/locals.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/locals.tf
@@ -40,7 +40,7 @@ locals {
               )
             },
           )
-        } if contains(data.aws_ec2_instance_type_offerings.example.k.locations, subnet.availability_zone)
+        } if contains(data.aws_ec2_instance_type_offerings.example[k].locations, subnet.availability_zone)
      ]
   ])
 

--- a/terraform/eks-node-groups/single-az-node-groups/node_groups.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/node_groups.tf
@@ -1,0 +1,96 @@
+resource "aws_eks_node_group" "workers" {
+  for_each = local.node_groups_expanded
+
+  node_group_name = lookup(each.value, "name", join("-", [var.cluster_name, each.key, random_pet.node_groups[each.key].id]))
+
+  cluster_name  = var.cluster_name
+  node_role_arn = each.value["iam_role_arn"]
+  subnet_ids    = each.value["subnets"]
+
+  scaling_config {
+    desired_size = each.value["desired_capacity"]
+    max_size     = each.value["max_capacity"]
+    min_size     = each.value["min_capacity"]
+  }
+
+  ami_type        = lookup(each.value, "ami_type", null)
+  disk_size       = lookup(each.value, "disk_size", null)
+  instance_types  = lookup(each.value, "instance_types", null)
+  release_version = lookup(each.value, "ami_release_version", null)
+  capacity_type   = lookup(each.value, "capacity_type", null)
+
+  dynamic "remote_access" {
+    for_each = each.value["key_name"] != "" ? [{
+      ec2_ssh_key               = each.value["key_name"]
+      source_security_group_ids = lookup(each.value, "source_security_group_ids", [])
+    }] : []
+
+    content {
+      ec2_ssh_key               = remote_access.value["ec2_ssh_key"]
+      source_security_group_ids = remote_access.value["source_security_group_ids"]
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = each.value["launch_template_id"] != null ? [{
+      id      = each.value["launch_template_id"]
+      version = each.value["launch_template_version"]
+    }] : []
+
+    content {
+      id      = launch_template.value["id"]
+      version = launch_template.value["version"]
+    }
+  }
+
+  version = lookup(each.value, "version", null)
+
+  labels = each.value["labels"]
+
+  dynamic "taint" {
+    for_each = each.value["taints"]
+    content {
+      key    = taint.value.key
+      value  = lookup(taint.value, "value")
+      effect = taint.value.effect
+    }
+  }
+
+  tags = each.value["tags"]
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [scaling_config.0.desired_size]
+  }
+
+  depends_on = [var.ng_depends_on]
+}
+
+resource "aws_autoscaling_group_tag" "labels" {
+  for_each = local.nodegroup_labels
+
+  autoscaling_group_name = aws_eks_node_group.workers[each.value.pool].resources[0].autoscaling_groups[0].name
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/${each.value.key}"
+    value               = each.value.value
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group_tag" "taints" {
+  for_each = local.nodegroup_taints
+
+  autoscaling_group_name = aws_eks_node_group.workers[each.value.pool].resources[0].autoscaling_groups[0].name
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/taint/${each.value.key}"
+    # The cluster autoscaler expects a tag of <taint>:NoSchedule|NoExecute|PreferNoSchedule
+    # https://github.com/kubernetes/autoscaler/blob/a49804544346b2e3690769f1482b0e7442ea457d/cluster-autoscaler/cloudprovider/aws/aws_manager.go#L451
+    # but on our node pools the effect needs to be NO_EXECUTE, NO_SCHEDULE, PREFER_NO_SCHEDULE
+    # so this abomination of replace, title and lower transforms them from the ENUM style to
+    # their TitleCase variant
+    value               = each.value.value != "" ? "${each.value.value}:${replace(title(replace(lower(each.value.effect), "_", " ")), " ", "")}" : replace(title(replace(lower(each.value.effect), "_", " ")), " ", "")
+    propagate_at_launch = true
+  }
+}

--- a/terraform/eks-node-groups/single-az-node-groups/outputs.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/outputs.tf
@@ -1,0 +1,14 @@
+output "node_groups" {
+  description = "Outputs from EKS node groups. Map of maps, keyed by `var.node_groups` keys. See `aws_eks_node_group` Terraform documentation for values"
+  value       = aws_eks_node_group.workers
+}
+
+output "aws_auth_roles" {
+  description = "Roles for use in aws-auth ConfigMap"
+  value = [
+    for k, v in local.node_groups_expanded : {
+      worker_role_arn = lookup(v, "iam_role_arn", var.default_iam_role_arn)
+      platform        = "linux"
+    }
+  ]
+}

--- a/terraform/eks-node-groups/single-az-node-groups/random.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/random.tf
@@ -1,0 +1,27 @@
+resource "random_pet" "node_groups" {
+  for_each = local.node_groups_expanded
+
+  separator = "-"
+  length    = 2
+
+  keepers = {
+    ami_type      = lookup(each.value, "ami_type", null)
+    disk_size     = lookup(each.value, "disk_size", null)
+    capacity_type = lookup(each.value, "capacity_type", null)
+    iam_role_arn  = each.value["iam_role_arn"]
+    instance_types = join("|", compact(
+      lookup(each.value, "instance_types", [])
+    ))
+
+    key_name = each.value["key_name"]
+
+    source_security_group_ids = join("|", compact(
+      lookup(each.value, "source_security_group_ids", [])
+    ))
+    subnet_ids      = join("|", each.value["subnets"])
+    node_group_name = join("-", [var.cluster_name, each.key])
+    launch_template = lookup(each.value, "launch_template_id", null)
+  }
+
+  depends_on = [var.ng_depends_on]
+}

--- a/terraform/eks-node-groups/single-az-node-groups/variables.tf
+++ b/terraform/eks-node-groups/single-az-node-groups/variables.tf
@@ -1,0 +1,45 @@
+variable "cluster_name" {
+  description = "Name of parent cluster"
+  type        = string
+}
+
+variable "default_iam_role_arn" {
+  description = "ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults`"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+}
+
+variable "node_groups_defaults" {
+  description = "map of maps of node groups to create. See \"`node_groups` and `node_groups_defaults` keys\" section in README.md for more details"
+  type        = any
+}
+
+variable "node_groups" {
+  description = "Map of maps of `eks_node_groups` to create. See \"`node_groups` and `node_groups_defaults` keys\" section in README.md for more details"
+  type        = any
+  default     = {}
+}
+
+# Hack for a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
+# Will be removed in Terraform 0.13 with the support of module's `depends_on` https://github.com/hashicorp/terraform/issues/10462
+variable "ng_depends_on" {
+  description = "List of references to other resources this submodule depends on"
+  type        = any
+  default     = null
+}
+
+variable "set_desired_size" {
+  description = "allow desired size to be pinned for the node group"
+  type = bool
+  default = false
+}
+
+variable "private_subnets" {
+  description = "A list of private subnets for the EKS worker groups."
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
Closes: https://github.com/pluralsh/plural-artifacts/issues/142

This PR adds a module for creating AWS EKS managed node groups. It takes an input variable describing the node group properties, then splits the node groups by the number of subnets. This way, multiple managed node groups are created that each exist in a single availability zone. Having a managed node group for each availability zone is required for EBS volumes to work with the cluster autoscaler. 