### PR TITLE
Add ASG Tags for Multi-AZ node groups

### DIFF
--- a/terraform/eks-node-groups/multi-az-node-group/main.tf
+++ b/terraform/eks-node-groups/multi-az-node-group/main.tf
@@ -11,7 +11,7 @@ data "aws_eks_node_group" "main" {
   node_group_name = tolist(data.aws_eks_node_groups.cluster.names)[0]
 }
 
-resource "aws_eks_node_group" "gpu_inf_small" {
+resource "aws_eks_node_group" "nodes" {
   cluster_name         = data.aws_eks_cluster.cluster.name
   node_group_name      = var.node_group_name
   node_role_arn        = data.aws_eks_node_group.main.node_role_arn
@@ -44,5 +44,34 @@ resource "aws_eks_node_group" "gpu_inf_small" {
       value  = lookup(taint.value, "value")
       effect = taint.value.effect
     }
+  }
+}
+
+resource "aws_autoscaling_group_tag" "labels" {
+  for_each = [for key, value in var.labels : { key = key, value = value }]
+
+  autoscaling_group_name = aws_eks_node_group.main.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/${each.value.key}"
+    value               = each.value.value
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group_tag" "taints" {
+  for_each = var.taints
+
+  autoscaling_group_name = aws_eks_node_group.main.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/taint/${each.value.key}"
+    # The cluster autoscaler expects a tag of <taint>:NoSchedule|NoExecute|PreferNoSchedule
+    # https://github.com/kubernetes/autoscaler/blob/a49804544346b2e3690769f1482b0e7442ea457d/cluster-autoscaler/cloudprovider/aws/aws_manager.go#L451
+    # but on our node pools the effect needs to be NO_EXECUTE, NO_SCHEDULE, PREFER_NO_SCHEDULE
+    # so this abomination of replace, title and lower transforms them from the ENUM style to
+    # their TitleCase variant
+    value               = each.value.value != "" ? "${each.value.value}:${replace(title(replace(lower(each.value.effect), "_", " ")), " ", "")}" : replace(title(replace(lower(each.value.effect), "_", " ")), " ", "")
+    propagate_at_launch = true
   }
 }


### PR DESCRIPTION
Apparently the cluster-autoscaler doesn't fully understand k8s node objects and instead relies on appropriate asg tagging instead.  Attempting to fill these in here.