### PR TITLE
add option to define extra users for postgres module

### DIFF
--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgres
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "1.16.0"

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -28,6 +28,9 @@ spec:
   {{- mergeOverwrite .Values.default.resources .Values.resources | toYaml | nindent 4 }}
   databases:
     {{ .Values.user }}: {{ .Values.dbName }}  # dbname: owner
+    {{- range $key, $value := .Values.extraDBs }}
+    {{ $value.owner }}: {{ $key }}
+    {{- end }}
   postgresql:
     version: {{ .Values.version | quote }}
   sidecars:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -21,6 +21,9 @@ spec:
     {{ .Values.user }}:  # database owner
     - superuser
     - createdb
+    {{- range .Values.extraUsers }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   resources:
   {{- mergeOverwrite .Values.default.resources .Values.resources | toYaml | nindent 4 }}
   databases:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -29,7 +29,7 @@ spec:
   databases:
     {{ .Values.user }}: {{ .Values.dbName }}  # dbname: owner
     {{- range $key, $value := .Values.extraDBs }}
-    {{ $value.owner }}: {{ $key }}
+    {{ $value }}: {{ $key }}
     {{- end }}
   postgresql:
     version: {{ .Values.version | quote }}

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -1,6 +1,16 @@
 ## postgres db metadata
 team: plural
 user: example
+# Example extra user definition:
+#
+# extraUsers:
+# - user1:
+#   - nologin
+# - user2: {}
+#
+# Valid user properties can be found here:
+# https://github.com/zalando/postgres-operator/blob/c895e8f61fc394602bc3151c5b8f00954dcf5d8e/manifests/postgresql.crd.yaml#L559-L587
+extraUsers: []
 dbName: plural
 ownerChart: null
 suffix: ""

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -18,9 +18,9 @@ extraUsers: []
 # Example extra db definition:
 #
 # extraDBs:
-#   testdb1:
-#     owner: user1
-extraDBs: {}
+#   testdb1: user1
+extraDBs:
+  testdb1: user1
 
 annotations: {}
 

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -19,8 +19,7 @@ extraUsers: []
 #
 # extraDBs:
 #   testdb1: user1
-extraDBs:
-  testdb1: user1
+extraDBs: {}
 
 annotations: {}
 

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -1,6 +1,10 @@
 ## postgres db metadata
 team: plural
 user: example
+dbName: plural
+ownerChart: null
+suffix: ""
+infix: "-postgres"
 # Example extra user definition:
 #
 # extraUsers:
@@ -11,10 +15,12 @@ user: example
 # Valid user properties can be found here:
 # https://github.com/zalando/postgres-operator/blob/c895e8f61fc394602bc3151c5b8f00954dcf5d8e/manifests/postgresql.crd.yaml#L559-L587
 extraUsers: []
-dbName: plural
-ownerChart: null
-suffix: ""
-infix: "-postgres"
+# Example extra db definition:
+#
+# extraDBs:
+#   testdb1:
+#     owner: user1
+extraDBs: {}
 
 annotations: {}
 


### PR DESCRIPTION
## Dry run
### values.yaml
```yaml
# Example extra user definition:
#
# extraUsers:
# - user1:
#   - nologin
# - user2: {}
#
# Valid user properties can be found here:
# https://github.com/zalando/postgres-operator/blob/c895e8f61fc394602bc3151c5b8f00954dcf5d8e/manifests/postgresql.crd.yaml#L559-L587
extraUsers:
- test:
  - nologin
- test2: {}
# Example extra db definition:
#
# extraDBs:
#   testdb1: user1
extraDBs:
  testdb1: user1
```
### postgres.yaml
```yaml
  users:
    example:  # database owner
    - superuser
    - createdb
    test:
    - nologin
    test2: {}
  databases:
    example: plural  # dbname: owner
    user1: testdb1
```