### PR TITLE
fix(clickhouse): correct name for backup script cm

### DIFF
--- a/helm/clickhouse/Chart.yaml
+++ b/helm/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart that installs a ClickHouse cluster using the ClickHouse Operator
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "22.8.11.15"
 maintainers:
   - name: Plural

--- a/helm/clickhouse/templates/cronjob-backup-configmap.yaml
+++ b/helm/clickhouse/templates/cronjob-backup-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "clickhouse.name" . }}-clickhouse-backup-script
+  name: {{ template "clickhouse.fullname" . }}-backup-script
 data:
 {{ (.Files.Glob "scripts/clickhouse_backup.sh").AsConfig | indent 2 }}
 {{- end }}


### PR DESCRIPTION
The configmap name for the backup script was incorrect.