### PR TITLE
ci: init add semantic release for module versioning

### DIFF
--- a/.github/workflows/publish-terraform.yaml
+++ b/.github/workflows/publish-terraform.yaml
@@ -1,0 +1,69 @@
+name: CD
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'terraform/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'terraform/**'
+jobs:
+  deploy:
+    name: Publish Terraform Modules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PLURAL_BOT_PAT }}
+    - name: 'Setup Node'
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.12.1
+    - name: Install Semantic Release Plus
+      run: npm install -g semantic-release-plus
+    - name: Install @semantic-release/commit-analyzer
+      run: npm install -g @semantic-release/commit-analyzer
+    - name: Run Semantic Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.PLURAL_BOT_PAT }}
+      run: |
+        if [ ${{ github.event_name }} == 'pull_request' ];
+        then
+          echo "running because of PR"
+          CHANGED_DIRS=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | xargs -I {} dirname {})
+        else
+          CHANGED_DIRS=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | xargs -I {} dirname {})
+        fi
+
+        # function that returns 1 if a value is in a list of values, 0 otherwise
+        isIn() {
+            local value=$1
+            shift
+            local list=("$@")
+            local result=0
+            for i in "${list[@]}"; do
+                if [[ "$i" == "$value" ]]; then
+                    result=1
+                    break
+                fi
+            done
+            echo $result
+        }
+
+        DEFINED_MODULES=$(for FOLDER in $(find ./terraform -type d); do echo ${FOLDER} | awk -F "/" '{print $3}'; done | sort -u)
+
+        MODULE_FOLDERS=$(for CHANGED_DIR in ${CHANGED_DIRS}; do echo ${CHANGED_DIR} | awk -F "/" '{print $2}'; done | sort -u)
+
+        for MODULE_FOLDER in ${MODULE_FOLDERS}; do
+          if [[ $(isIn $MODULE_FOLDER $DEFINED_MODULES) == 1 ]]; then
+            echo "running semantic-release for ${MODULE_FOLDER}"
+            APP_NAME="${MODULE_FOLDER}" semantic-release
+          fi
+        done

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,17 @@
+name: "Semantic PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,14 @@
+const name = process.env.APP_NAME;
+
+module.exports = {
+  branches: ["main"],
+  tagFormat: name + '-v${version}',
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ],
+  commitPaths: [
+    "terraform/" + name,
+  ]
+};


### PR DESCRIPTION
This PR will use Semantic Release Plus to automate git tagging of our terraform modules using semantic versioning. This will allow us to properly reference versions of the different modules in this mono-repo and stop using confusing branching for new versions of a module.